### PR TITLE
Fix README -- radius.authenticate arg order

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Here is an example of using the library.
 
     import radius
 
-    radius.authenticate(username, password, secret, host='radius', port=1812)
+    radius.authenticate(secret, username, password, host='radius', port=1812)
 
     # - OR -
 


### PR DESCRIPTION
The order of arguments for radius.authenticate changed in https://github.com/btimby/py-radius/commit/a771db7135fd090657e4027bae49a311871804ea, this just updates the README accordingly.