### PR TITLE
Fix long description and licence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,22 +10,20 @@ versrel = version + '-' + release
 download_url = 'https://github.com/downloads/btimby/' + name + \
                            '/' + name + '-' + versrel + '.tar.gz'
 
-with open('LICENSE', 'r') as l:
-    license = l.read()
+with open('README.rst', 'r') as rm:
+    long_description = rm.read()
 
 setup(
     name = name,
     version = versrel,
     description = 'RADIUS authentication module',
-    long_description = 'A pure Python module that implements client side RADIUS ' \
-                       'authentication, as defined by RFC2865.',
+    long_description=long_description,
     author = 'Stuart Bishop',
     author_email = 'zen@shangri-la.dropbear.id.au',
     maintainer = 'Ben Timby',
     maintainer_email = 'btimby@gmail.com',
     url = 'http://github.com/btimby/' + name + '/',
     download_url = download_url,
-    license = license,
     py_modules = ["radius"],
     classifiers = [
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
pypi.org now requires long_description values render correctly.
license should not contain the full text of the licence:
  > The license field is a text indicating the license covering the package where the license is not a selection from the “License” Trove classifiers. See the Classifier field. Notice that there’s a licence distribution option which is deprecated but still acts as an alias for license.
https://docs.python.org/3/distutils/setupscript.html#additional-meta-data